### PR TITLE
add map() method

### DIFF
--- a/SwiftEither/Either.swift
+++ b/SwiftEither/Either.swift
@@ -42,7 +42,16 @@ public enum Either<S, F> {
             return f()
         }
     }
-
+	
+	public func map<S0>(f: S -> S0) -> Either<S0, F> {
+		switch self {
+		case .Success(let s):
+			return Either<S0, F>(success: f(s.value))
+		case .Failure(let f):
+			return Either<S0, F>.Failure(f)
+		}
+	}
+	
     public var successValue: S? {
         switch self {
         case .Success(let s):

--- a/SwiftEitherTests/SwiftEitherTests.swift
+++ b/SwiftEitherTests/SwiftEitherTests.swift
@@ -127,6 +127,28 @@ class SwiftEitherTests: XCTestCase {
             XCTAssert(false, "not reached")
         }
     }
+	
+	func testMapMethodLeftUsed() {
+		let e = try(true, "foo").map { "\($0) bar" }
+		
+		switch e {
+		case .Success(let l):
+			XCTAssertEqual(l.value, "foo bar")
+		case .Failure(let r):
+			XCTFail("not reached")
+		}
+	}
+	
+	func testMapMethodRightUsed() {
+		let e = try(false, "foo").map { "\($0) bar" }
+		
+		switch e {
+		case .Success(let l):
+			XCTFail("not reached")
+		case .Failure(let r):
+			XCTAssertEqual(r.value.reason, "foo")
+		}
+	}
 
     func testSuccessValue() {
         let e = try(true, "foo")


### PR DESCRIPTION
I implemented the `map` method (and its test) that is similar to the one in `Optional`.

``` swift
let e1 = try(true, "foo").map { "\($0) bar" } // "foo bar"
let e2 = try(false, "foo").map { "\($0) bar" } // "foo"
```

I think the `map` method is useful and necessary for `Either` to be something like a _Functor_.
