### PR TITLE
replace tabs in the codes with spaces

### DIFF
--- a/SwiftEither/Either.swift
+++ b/SwiftEither/Either.swift
@@ -42,16 +42,16 @@ public enum Either<S, F> {
             return f()
         }
     }
-	
-	public func map<S0>(f: S -> S0) -> Either<S0, F> {
-		switch self {
-		case .Success(let s):
-			return Either<S0, F>(success: f(s.value))
-		case .Failure(let f):
-			return Either<S0, F>.Failure(f)
-		}
-	}
-	
+    
+    public func map<S0>(f: S -> S0) -> Either<S0, F> {
+        switch self {
+        case .Success(let s):
+            return Either<S0, F>(success: f(s.value))
+        case .Failure(let f):
+            return Either<S0, F>.Failure(f)
+        }
+    }
+    
     public var successValue: S? {
         switch self {
         case .Success(let s):

--- a/SwiftEitherTests/SwiftEitherTests.swift
+++ b/SwiftEitherTests/SwiftEitherTests.swift
@@ -127,28 +127,28 @@ class SwiftEitherTests: XCTestCase {
             XCTAssert(false, "not reached")
         }
     }
-	
-	func testMapMethodLeftUsed() {
-		let e = try(true, "foo").map { "\($0) bar" }
-		
-		switch e {
-		case .Success(let l):
-			XCTAssertEqual(l.value, "foo bar")
-		case .Failure(let r):
-			XCTFail("not reached")
-		}
-	}
-	
-	func testMapMethodRightUsed() {
-		let e = try(false, "foo").map { "\($0) bar" }
-		
-		switch e {
-		case .Success(let l):
-			XCTFail("not reached")
-		case .Failure(let r):
-			XCTAssertEqual(r.value.reason, "foo")
-		}
-	}
+    
+    func testMapMethodLeftUsed() {
+        let e = try(true, "foo").map { "\($0) bar" }
+        
+        switch e {
+        case .Success(let l):
+            XCTAssertEqual(l.value, "foo bar")
+        case .Failure(let r):
+            XCTFail("not reached")
+        }
+    }
+    
+    func testMapMethodRightUsed() {
+        let e = try(false, "foo").map { "\($0) bar" }
+        
+        switch e {
+        case .Success(let l):
+            XCTFail("not reached")
+        case .Failure(let r):
+            XCTAssertEqual(r.value.reason, "foo")
+        }
+    }
 
     func testSuccessValue() {
         let e = try(true, "foo")


### PR DESCRIPTION
Sorry. I fixed my mistake about indentation. Please merge again.

In the commit d70bdf7f2b8d928b0696b039ff25eb4c40d42969, my codes were indented by tabs although your codes were indented by spaces.
